### PR TITLE
interpolateParams=true で ADMIN PREPARE を減らす

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -305,7 +305,7 @@ func main() {
 	}
 
 	dsn := fmt.Sprintf(
-		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=true&loc=Local",
+		"%s:%s@tcp(%s:%s)/%s?interpolateParams=true&charset=utf8mb4&parseTime=true&loc=Local",
 		user,
 		password,
 		host,


### PR DESCRIPTION
https://github.com/JSON-Voorhees/isucon9-qualify-study/issues/1#issuecomment-1179649755

一番上に ADMIN PREPARE が来ているので、interpolateParams=true を設定して消す